### PR TITLE
Add access keys for team coach registration.

### DIFF
--- a/BwMelder/BwMelder.csproj
+++ b/BwMelder/BwMelder.csproj
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.13" />
   </ItemGroup>
 
 </Project>

--- a/BwMelder/Data/BwMelderDbContext.cs
+++ b/BwMelder/Data/BwMelderDbContext.cs
@@ -17,6 +17,7 @@ namespace BwMelder.Data
 
         public DbSet<HomeCoach> HomeCoaches => Set<HomeCoach>();
         public DbSet<TeamCoach> TeamCoaches => Set<TeamCoach>();
+        public DbSet<TeamCoachKey> TeamCoachKeys => Set<TeamCoachKey>();
 
         public BwMelderDbContext(DbContextOptions<BwMelderDbContext> options) : base(options) { }
         

--- a/BwMelder/Extensions/HttpRequestExtensions.cs
+++ b/BwMelder/Extensions/HttpRequestExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+
+namespace BwMelder.Extensions
+{
+    public static class HttpRequestExtensions
+    {
+        public static string? BaseUrl(this HttpRequest req)
+        {
+            if (req == null) return null;
+            var uriBuilder = new UriBuilder(req.Scheme, req.Host.Host, req.Host.Port ?? -1);
+            if (uriBuilder.Uri.IsDefaultPort)
+            {
+                uriBuilder.Port = -1;
+            }
+
+            return uriBuilder.Uri.AbsoluteUri;
+        }
+    }
+}

--- a/BwMelder/Migrations/20230527073941_InitializeDatabase.Designer.cs
+++ b/BwMelder/Migrations/20230527073941_InitializeDatabase.Designer.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BwMelder.Migrations
 {
     [DbContext(typeof(BwMelderDbContext))]
-    [Migration("20230526163003_InitializeDatabase")]
+    [Migration("20230527073941_InitializeDatabase")]
     partial class InitializeDatabase
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -333,6 +333,23 @@ namespace BwMelder.Migrations
                         });
                 });
 
+            modelBuilder.Entity("BwMelder.Model.TeamCoachKey", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("Comment")
+                        .HasColumnType("TEXT");
+
+                    b.Property<Guid>("Secret")
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("TeamCoachKeys");
+                });
+
             modelBuilder.Entity("BwMelder.Model.Athlete", b =>
                 {
                     b.HasBaseType("BwMelder.Model.Participant");
@@ -358,6 +375,12 @@ namespace BwMelder.Migrations
 
                     b.Property<int>("DriversLicense")
                         .HasColumnType("INTEGER");
+
+                    b.Property<int?>("TeamCoachKeyId")
+                        .HasColumnType("INTEGER");
+
+                    b.HasIndex("TeamCoachKeyId")
+                        .IsUnique();
 
                     b.HasDiscriminator().HasValue("TeamCoach");
                 });
@@ -518,6 +541,10 @@ namespace BwMelder.Migrations
 
             modelBuilder.Entity("BwMelder.Model.TeamCoach", b =>
                 {
+                    b.HasOne("BwMelder.Model.TeamCoachKey", "TeamCoachKey")
+                        .WithOne("TeamCoach")
+                        .HasForeignKey("BwMelder.Model.TeamCoach", "TeamCoachKeyId");
+
                     b.OwnsOne("BwMelder.Model.Contact", "Contact", b1 =>
                         {
                             b1.Property<Guid>("TeamCoachId")
@@ -541,6 +568,8 @@ namespace BwMelder.Migrations
 
                     b.Navigation("Contact")
                         .IsRequired();
+
+                    b.Navigation("TeamCoachKey");
                 });
 
             modelBuilder.Entity("BwMelder.Model.Crew", b =>
@@ -553,6 +582,11 @@ namespace BwMelder.Migrations
             modelBuilder.Entity("BwMelder.Model.Race", b =>
                 {
                     b.Navigation("Crews");
+                });
+
+            modelBuilder.Entity("BwMelder.Model.TeamCoachKey", b =>
+                {
+                    b.Navigation("TeamCoach");
                 });
 #pragma warning restore 612, 618
         }

--- a/BwMelder/Migrations/20230527073941_InitializeDatabase.cs
+++ b/BwMelder/Migrations/20230527073941_InitializeDatabase.cs
@@ -26,6 +26,20 @@ namespace BwMelder.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "TeamCoachKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Secret = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Comment = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeamCoachKeys", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "Crews",
                 columns: table => new
                 {
@@ -91,7 +105,8 @@ namespace BwMelder.Migrations
                     Contact_Phone = table.Column<string>(type: "TEXT", nullable: true),
                     Contact_EmailAddress = table.Column<string>(type: "TEXT", nullable: true),
                     ClubName = table.Column<string>(type: "TEXT", nullable: true),
-                    DriversLicense = table.Column<int>(type: "INTEGER", nullable: true)
+                    DriversLicense = table.Column<int>(type: "INTEGER", nullable: true),
+                    TeamCoachKeyId = table.Column<int>(type: "INTEGER", nullable: true)
                 },
                 constraints: table =>
                 {
@@ -102,6 +117,11 @@ namespace BwMelder.Migrations
                         principalTable: "Crews",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Participants_TeamCoachKeys_TeamCoachKeyId",
+                        column: x => x.TeamCoachKeyId,
+                        principalTable: "TeamCoachKeys",
+                        principalColumn: "Id");
                 });
 
             migrationBuilder.InsertData(
@@ -249,6 +269,12 @@ namespace BwMelder.Migrations
                 name: "IX_Participants_CrewId",
                 table: "Participants",
                 column: "CrewId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Participants_TeamCoachKeyId",
+                table: "Participants",
+                column: "TeamCoachKeyId",
+                unique: true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -261,6 +287,9 @@ namespace BwMelder.Migrations
 
             migrationBuilder.DropTable(
                 name: "Crews");
+
+            migrationBuilder.DropTable(
+                name: "TeamCoachKeys");
 
             migrationBuilder.DropTable(
                 name: "Races");

--- a/BwMelder/Migrations/BwMelderDbContextModelSnapshot.cs
+++ b/BwMelder/Migrations/BwMelderDbContextModelSnapshot.cs
@@ -331,6 +331,23 @@ namespace BwMelder.Migrations
                         });
                 });
 
+            modelBuilder.Entity("BwMelder.Model.TeamCoachKey", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("Comment")
+                        .HasColumnType("TEXT");
+
+                    b.Property<Guid>("Secret")
+                        .HasColumnType("TEXT");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("TeamCoachKeys");
+                });
+
             modelBuilder.Entity("BwMelder.Model.Athlete", b =>
                 {
                     b.HasBaseType("BwMelder.Model.Participant");
@@ -356,6 +373,12 @@ namespace BwMelder.Migrations
 
                     b.Property<int>("DriversLicense")
                         .HasColumnType("INTEGER");
+
+                    b.Property<int?>("TeamCoachKeyId")
+                        .HasColumnType("INTEGER");
+
+                    b.HasIndex("TeamCoachKeyId")
+                        .IsUnique();
 
                     b.HasDiscriminator().HasValue("TeamCoach");
                 });
@@ -516,6 +539,10 @@ namespace BwMelder.Migrations
 
             modelBuilder.Entity("BwMelder.Model.TeamCoach", b =>
                 {
+                    b.HasOne("BwMelder.Model.TeamCoachKey", "TeamCoachKey")
+                        .WithOne("TeamCoach")
+                        .HasForeignKey("BwMelder.Model.TeamCoach", "TeamCoachKeyId");
+
                     b.OwnsOne("BwMelder.Model.Contact", "Contact", b1 =>
                         {
                             b1.Property<Guid>("TeamCoachId")
@@ -539,6 +566,8 @@ namespace BwMelder.Migrations
 
                     b.Navigation("Contact")
                         .IsRequired();
+
+                    b.Navigation("TeamCoachKey");
                 });
 
             modelBuilder.Entity("BwMelder.Model.Crew", b =>
@@ -551,6 +580,11 @@ namespace BwMelder.Migrations
             modelBuilder.Entity("BwMelder.Model.Race", b =>
                 {
                     b.Navigation("Crews");
+                });
+
+            modelBuilder.Entity("BwMelder.Model.TeamCoachKey", b =>
+                {
+                    b.Navigation("TeamCoach");
                 });
 #pragma warning restore 612, 618
         }

--- a/BwMelder/Model/TeamCoach.cs
+++ b/BwMelder/Model/TeamCoach.cs
@@ -18,5 +18,8 @@ namespace BwMelder.Model
 
         [Display(Name = "Führerschein")]
         public DriversLicense DriversLicense { get; set; } = DriversLicense.None;
+
+        public int? TeamCoachKeyId { get; set; } = null;
+        public TeamCoachKey? TeamCoachKey { get; set; } = null;
     }
 }

--- a/BwMelder/Model/TeamCoachKey.cs
+++ b/BwMelder/Model/TeamCoachKey.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace BwMelder.Model
 {
@@ -7,10 +8,12 @@ namespace BwMelder.Model
         public int Id { get; set; } = 0;
 
         // Guid is used as secret key because it is hard to guess and collision-free.
+        [Display(Name = "Schlüssel")]
         public Guid Secret { get; private set; } = Guid.NewGuid();
 
         public virtual TeamCoach? TeamCoach { get; set; } = null;
 
+        [Display(Name = "Verwendung")]
         public string? Comment { get; set; } = string.Empty;
     }
 }

--- a/BwMelder/Model/TeamCoachKey.cs
+++ b/BwMelder/Model/TeamCoachKey.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace BwMelder.Model
+{
+    public class TeamCoachKey
+    {
+        public int Id { get; set; } = 0;
+
+        // Guid is used as secret key because it is hard to guess and collision-free.
+        public Guid Secret { get; private set; } = Guid.NewGuid();
+
+        public virtual TeamCoach? TeamCoach { get; set; } = null;
+
+        public string? Comment { get; set; } = string.Empty;
+    }
+}

--- a/BwMelder/Pages/Crews/Details.cshtml
+++ b/BwMelder/Pages/Crews/Details.cshtml
@@ -15,10 +15,10 @@
     <p>
         Über diesen Link können weitere Personen ohne Anmeldung auf die Mannschaftsdetails zugreifen und Eintragungen vornehmen:
     </p>
-    <div class="input-group mb-3">
-        <input id="shareLink" class="form-control" readonly />
+    <div class="input-group">
+        <input class="form-control" readonly value="@Model.GetSecretUrl()"/>
         <div class="input-group-append">
-            <button class="btn btn-outline-secondary" data-toggle="button" onclick="toggleQrCode()">QR-Code</button>
+            <button class="btn btn-outline-secondary" data-toggle="button" onclick="toggleQrCode('@Model.GetSecretUrl()', 'qrCode')">QR-Code</button>
         </div>
     </div>
     <div class="d-flex justify-content-center">
@@ -129,26 +129,7 @@ else
 }
 
 @section Scripts {
-
-    <script type="text/javascript" src="~/lib/qrcodejs/qrcode.min.js"></script>
-    <script type="text/javascript">
-        document.getElementById("shareLink").value = window.location.href;
-
-        function toggleQrCode() {
-            qrCodeContainer = document.getElementById("qrCode");
-
-            if (qrCodeContainer.innerHTML.trim().length > 0) {
-                qrCodeContainer.innerHTML = "";
-            }
-            else {
-                new QRCode(qrCodeContainer,
-                    {
-                        text: window.location.href,
-                        width: 150,
-                        height: 150
-                    });
-            }
-        }
-    </script>
-
+    @{
+        await Html.RenderPartialAsync("_QrCodeScriptsPartial");
+    }
 }

--- a/BwMelder/Pages/Crews/Details.cshtml.cs
+++ b/BwMelder/Pages/Crews/Details.cshtml.cs
@@ -7,34 +7,44 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using BwMelder.Data;
 using BwMelder.Model;
+using Microsoft.AspNetCore.Http;
+using BwMelder.Extensions;
 
 namespace BwMelder.Pages.Crews
 {
     public class DetailsModel : PageModel
     {
-        private readonly BwMelderDbContext _context;
+        private readonly BwMelderDbContext db;
+        private readonly IHttpContextAccessor httpContextAccessor;
 
-        public DetailsModel(BwMelderDbContext context)
+        public DetailsModel(BwMelderDbContext db, IHttpContextAccessor httpContextAccessor)
         {
-            _context = context;
+            this.db = db;
+            this.httpContextAccessor = httpContextAccessor;
         }
 
-        public Crew Crew { get; set; }
+        public Crew? Crew { get; set; }
+        public string BaseUrl { get; set; } = string.Empty;
 
         public async Task<IActionResult> OnGetAsync(Guid id)
         {
-            Crew = await _context.Crews
+            Crew = await db.Crews
                 .AsNoTracking()
                 .Include(c => c.HomeCoach)
                 .Include(c => c.Race)
                 .Include(c => c.Athletes)
-                .FirstOrDefaultAsync(m => m.Id == id);
+                .SingleOrDefaultAsync(m => m.Id == id);
 
             if (Crew == null)
             {
                 return NotFound();
             }
+
+            BaseUrl = httpContextAccessor.HttpContext?.Request.BaseUrl() ?? string.Empty;
+
             return Page();
         }
+
+        public string GetSecretUrl() => $"{BaseUrl}Crews/Details/{Crew?.Id}";
     }
 }

--- a/BwMelder/Pages/Shared/_QrCodeScriptsPartial.cshtml
+++ b/BwMelder/Pages/Shared/_QrCodeScriptsPartial.cshtml
@@ -1,0 +1,21 @@
+﻿<script type="text/javascript" src="~/lib/qrcodejs/qrcode.min.js"></script>
+<script type="text/javascript">
+    function toggleQrCode(url, qr) {
+        qrCodeContainer = document.getElementById(qr);
+
+        if (qrCodeContainer.innerHTML.trim().length > 0) {
+            qrCodeContainer.innerHTML = "";
+            qrCodeContainer.classList.remove("mt-2");
+        }
+        else {
+            new QRCode(qrCodeContainer,
+                {
+                    text: url,
+                    width: 150,
+                    height: 150
+                });
+
+            qrCodeContainer.classList.add("mt-2");
+        }
+    }
+</script>

--- a/BwMelder/Pages/Shared/_TeamCoachForm.cshtml
+++ b/BwMelder/Pages/Shared/_TeamCoachForm.cshtml
@@ -85,6 +85,8 @@
         <span asp-validation-for="Comments" class="text-danger"></span>
     </div>
 
+    <input type="hidden" asp-for="TeamCoachKeyId" />
+
     <div class="form-group">
         <input type="submit" value="Speichern" class="btn btn-primary" />
     </div>

--- a/BwMelder/Pages/TeamCoaches/Create.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "{secret:guid?}"
 @model BwMelder.Pages.TeamCoaches.CreateModel
 
 @{

--- a/BwMelder/Pages/TeamCoaches/Create.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Create.cshtml.cs
@@ -27,7 +27,7 @@ namespace BwMelder.Pages.TeamCoaches
             {
                 var key = await db.TeamCoachKeys
                     .AsNoTracking()
-                    .FirstOrDefaultAsync(key => key.Secret == secret);
+                    .SingleOrDefaultAsync(key => key.Secret == secret);
 
                 if (key != null)
                 {

--- a/BwMelder/Pages/TeamCoaches/Create.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Create.cshtml.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using BwMelder.Data;
 using BwMelder.Model;
+using Microsoft.EntityFrameworkCore;
 
 namespace BwMelder.Pages.TeamCoaches
 {
@@ -19,9 +20,32 @@ namespace BwMelder.Pages.TeamCoaches
             this.db = db;
         }
 
-        public IActionResult OnGet()
+        public async Task<IActionResult> OnGetAsync(Guid? secret)
         {
-            return Page();
+            // Check for a valid key.
+            if (secret != null)
+            {
+                var key = await db.TeamCoachKeys
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(key => key.Secret == secret);
+
+                if (key != null)
+                {
+                    // Attach key to new team coach entry so the key cannot be used for another new entry.
+                    // Must be done for authenticated users as well to ensure data consistency.
+                    TeamCoach.TeamCoachKeyId = key.Id;
+                    return Page();
+                }
+            }
+
+            // Authenticated users are allowed to create team coaches without a key.
+            if (User.Identity?.IsAuthenticated ?? false)
+            {
+                return Page();
+            }
+
+            // Fail for unauthenticated users without key or with invalid key.
+            return Forbid();
         }
 
         [BindProperty]
@@ -33,6 +57,30 @@ namespace BwMelder.Pages.TeamCoaches
             if (!ModelState.IsValid)
             {
                 return Page();
+            }
+
+            // If a key is already attached, make sure it is still valid and the right one.
+            if (TeamCoach.TeamCoachKeyId != null)
+            {
+                var key = await db.TeamCoachKeys
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(key => key.Id == TeamCoach.TeamCoachKeyId);
+
+                if (key == null)
+                {
+                    // TODO: Change to meaningful error message.
+                    return BadRequest();
+                }
+            }
+            // If the key is not yet set, generate and save a new key.
+            else
+            {
+                var key = new TeamCoachKey
+                {
+                    Comment = $"Generated for {TeamCoach.FullName} at {DateTime.Now.ToString()}"
+                };
+                db.TeamCoachKeys.Add(key);
+                TeamCoach.TeamCoachKey = key;
             }
 
             db.TeamCoaches.Add(TeamCoach);

--- a/BwMelder/Pages/TeamCoaches/Delete.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Delete.cshtml.cs
@@ -62,12 +62,7 @@ namespace BwMelder.Pages.TeamCoaches
                 await db.SaveChangesAsync();
             }
 
-            // Return authenticated users to the overview, anonymous users to the homepage.
-            if (User.Identity?.IsAuthenticated ?? false)
-            {
-                return RedirectToPage("./Index");
-            }
-            return RedirectToPage("/");
+            return RedirectToPage("./Index");
         }
     }
 }

--- a/BwMelder/Pages/TeamCoaches/Delete.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Delete.cshtml.cs
@@ -20,7 +20,7 @@ namespace BwMelder.Pages.TeamCoaches
         }
 
         [BindProperty]
-        public TeamCoach TeamCoach { get; set; }
+        public TeamCoach? TeamCoach { get; set; }
 
         public async Task<IActionResult> OnGetAsync(Guid id)
         {
@@ -48,15 +48,26 @@ namespace BwMelder.Pages.TeamCoaches
             if (TeamCoach != null)
             {
                 db.TeamCoaches.Remove(TeamCoach);
+
+                // Check for an attached key and delete it too.
+                if (TeamCoach.TeamCoachKeyId != null)
+                {
+                    var key = await db.TeamCoachKeys.FindAsync(TeamCoach.TeamCoachKeyId);
+                    if (key != null)
+                    {
+                        db.TeamCoachKeys.Remove(key);
+                    }
+                }
+
                 await db.SaveChangesAsync();
             }
 
-            // Return authenticated users to the overview, anonymous users to the creation form.
+            // Return authenticated users to the overview, anonymous users to the homepage.
             if (User.Identity?.IsAuthenticated ?? false)
             {
                 return RedirectToPage("./Index");
             }
-            return RedirectToPage("./Create");
+            return RedirectToPage("/");
         }
     }
 }

--- a/BwMelder/Pages/TeamCoaches/Index.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Index.cshtml
@@ -8,9 +8,12 @@
 <h1>Betreuer</h1>
 <p>
     Hier werden die Betreuer verwaltet, die mit dem Team zum Bundeswettbewerb fahren.
+    Betreuer können ihre Daten über einen Betreuerzugang selbst eintragen und ändern.
 </p>
 <p>
-    <a class="btn btn-primary" asp-page="Create">Neuen Betreuer hinzufügen</a>
+    <a class="btn btn-primary" asp-page="./Keys/Create">Betreuerzugang anlegen</a>
+    <a class="btn btn-link" asp-page="./Keys/Index">Betreuerzugänge verwalten</a>
+    <a class="btn btn-link" asp-page="./Create">Betreuer selbst eintragen</a>
 </p>
 <table class="table">
     <thead>

--- a/BwMelder/Pages/TeamCoaches/Key.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Key.cshtml
@@ -1,0 +1,9 @@
+﻿@page "{secret:guid}"
+@model BwMelder.Pages.TeamCoaches.KeyModel
+@{
+    ViewData["Title"] = "Weiterleitung...";
+}
+
+<div>
+    <p>Einen Moment, wir leiten dich weiter...</p>
+</div>

--- a/BwMelder/Pages/TeamCoaches/Key.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Key.cshtml.cs
@@ -1,0 +1,44 @@
+using BwMelder.Data;
+using BwMelder.Model;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BwMelder.Pages.TeamCoaches
+{
+    public class KeyModel : PageModel
+    {
+        private readonly BwMelderDbContext db;
+
+        public KeyModel(BwMelderDbContext db)
+        {
+            this.db = db;
+        }
+
+        public async Task<IActionResult> OnGetAsync(Guid secret)
+        {
+            var teamCoachKey = await db.TeamCoachKeys
+                .AsNoTracking()
+                .Include(tck => tck.TeamCoach)
+                .FirstOrDefaultAsync(tck => tck.Secret == secret);
+
+            // Cancel if an invalid key was presented.
+            if (teamCoachKey == null)
+            {
+                return BadRequest();
+            }
+
+            // Go to adding a new team coach if none is attached to that key yet.
+            if (teamCoachKey.TeamCoach == null)
+            {
+                return RedirectToPage("./Create", new { secret });
+            }
+
+            // Go to the team coach attached to this key.
+            return RedirectToPage("./Details", new { id = teamCoachKey.TeamCoach.Id });
+        }
+    }
+}

--- a/BwMelder/Pages/TeamCoaches/Key.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Key.cshtml.cs
@@ -20,25 +20,25 @@ namespace BwMelder.Pages.TeamCoaches
 
         public async Task<IActionResult> OnGetAsync(Guid secret)
         {
-            var teamCoachKey = await db.TeamCoachKeys
+            var key = await db.TeamCoachKeys
                 .AsNoTracking()
-                .Include(tck => tck.TeamCoach)
-                .FirstOrDefaultAsync(tck => tck.Secret == secret);
+                .Include(key => key.TeamCoach)
+                .SingleOrDefaultAsync(key => key.Secret == secret);
 
             // Cancel if an invalid key was presented.
-            if (teamCoachKey == null)
+            if (key == null)
             {
                 return BadRequest();
             }
 
             // Go to adding a new team coach if none is attached to that key yet.
-            if (teamCoachKey.TeamCoach == null)
+            if (key.TeamCoach == null)
             {
                 return RedirectToPage("./Create", new { secret });
             }
 
             // Go to the team coach attached to this key.
-            return RedirectToPage("./Details", new { id = teamCoachKey.TeamCoach.Id });
+            return RedirectToPage("./Details", new { id = key.TeamCoach.Id });
         }
     }
 }

--- a/BwMelder/Pages/TeamCoaches/Keys/Create.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Keys/Create.cshtml
@@ -1,0 +1,35 @@
+﻿@page
+@model BwMelder.Pages.TeamCoaches.Keys.CreateModel
+
+@{
+    ViewData["Title"] = "Betreuerzugang anlegen";
+}
+
+<h1>@ViewData["Title"]</h1>
+<hr />
+
+<div class="row">
+    <div class="col-md-4">
+        <form method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Key.Comment" class="control-label"></label>
+                <input asp-for="Key.Comment" class="form-control" />
+                <span asp-validation-for="Key.Comment" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Speichern" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-page="./Index">Zurück zur Übersicht</a>
+</div>
+
+@section Scripts {
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+}

--- a/BwMelder/Pages/TeamCoaches/Keys/Create.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Keys/Create.cshtml.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using BwMelder.Data;
+using BwMelder.Model;
+
+namespace BwMelder.Pages.TeamCoaches.Keys
+{
+    public class CreateModel : PageModel
+    {
+        private readonly BwMelderDbContext db;
+
+        public CreateModel(BwMelderDbContext db)
+        {
+            this.db = db;
+        }
+
+        public IActionResult OnGet()
+        {
+            return Page();
+        }
+
+        [BindProperty]
+        public TeamCoachKey Key { get; set; } = new();
+
+        // To protect from overposting attacks, see https://aka.ms/RazorPagesCRUD
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            if (string.IsNullOrEmpty(Key.Comment))
+            {
+                Key.Comment = $"Generated at {DateTime.Now.ToString()}";
+            }
+
+            db.TeamCoachKeys.Add(Key);
+            await db.SaveChangesAsync();
+
+            return RedirectToPage("./Details", new { id = Key.Id });
+        }
+    }
+}

--- a/BwMelder/Pages/TeamCoaches/Keys/Delete.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Keys/Delete.cshtml
@@ -1,0 +1,36 @@
+﻿@page "{id:int}"
+@model BwMelder.Pages.TeamCoaches.Keys.DeleteModel
+
+@{
+    ViewData["Title"] = "Betreuerzugang löschen";
+}
+
+<h1>@ViewData["Title"]</h1>
+<hr />
+
+<p class="alert alert-danger">Soll dieser Zugang wirklich gelöscht werden?</p>
+
+<div>
+    <dl class="row">
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Key!.Comment)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Key!.Comment)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Key!.Secret)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Key!.Secret)
+        </dd>
+    </dl>
+</div>
+
+<div>
+    <form method="post">
+        <input type="hidden" asp-for="Key!.Id" />
+        <input type="submit" value="Löschen" class="btn btn-danger" /> |
+        <a asp-page="./Index">Zurück zur Übersicht</a>
+    </form>
+</div>

--- a/BwMelder/Pages/TeamCoaches/Keys/Delete.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Keys/Delete.cshtml.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using BwMelder.Data;
+using BwMelder.Model;
+
+namespace BwMelder.Pages.TeamCoaches.Keys
+{
+    public class DeleteModel : PageModel
+    {
+        private readonly BwMelderDbContext db;
+
+        public DeleteModel(BwMelderDbContext db)
+        {
+            this.db = db;
+        }
+
+        [BindProperty]
+        public TeamCoachKey? Key { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int id)
+        {
+            Key = await db.TeamCoachKeys
+                .AsNoTracking()
+                .SingleOrDefaultAsync(key => key.Id == id);
+
+            if (Key == null)
+            {
+                return NotFound();
+            }
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            Key = await db.TeamCoachKeys.FindAsync(id);
+
+            if (Key != null)
+            {
+                db.TeamCoachKeys.Remove(Key);
+                await db.SaveChangesAsync();
+            }
+
+            return RedirectToPage("./Index");
+        }
+    }
+}

--- a/BwMelder/Pages/TeamCoaches/Keys/Details.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Keys/Details.cshtml
@@ -43,27 +43,7 @@
 </div>
 
 @section Scripts {
-
-    <script type="text/javascript" src="~/lib/qrcodejs/qrcode.min.js"></script>
-    <script type="text/javascript">
-        function toggleQrCode(url, qr) {
-            qrCodeContainer = document.getElementById(qr);
-
-            if (qrCodeContainer.innerHTML.trim().length > 0) {
-                qrCodeContainer.innerHTML = "";
-                qrCodeContainer.classList.remove("mt-2");
-            }
-            else {
-                new QRCode(qrCodeContainer,
-                    {
-                        text: url,
-                        width: 150,
-                        height: 150
-                    });
-
-                qrCodeContainer.classList.add("mt-2");
-            }
-        }
-    </script>
-
+    @{
+        await Html.RenderPartialAsync("_QrCodeScriptsPartial");
+    }
 }

--- a/BwMelder/Pages/TeamCoaches/Keys/Details.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Keys/Details.cshtml
@@ -1,5 +1,5 @@
 ﻿@page "{id:int}"
-@model BwMelder.Pages.TeamCoaches.Keys.DeleteModel
+@model BwMelder.Pages.TeamCoaches.Keys.DetailsModel
 
 @{
     ViewData["Title"] = "Betreuerzugang";
@@ -20,7 +20,18 @@
             @Html.DisplayNameFor(model => model.Key!.Secret)
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Key!.Secret)
+            <div class="input-group">
+                <input class="form-control" value="@Model.GetSecretUrl(Model.Key!)" readonly />
+                <div class="input-group-append">
+                    <button class="btn btn-outline-secondary" data-toggle="button"
+                            onclick="toggleQrCode('@Model.GetSecretUrl(Model.Key!)', 'qrCode-@Model.Key!.Id')">
+                        QR-Code
+                    </button>
+                </div>
+            </div>
+            <div class="d-flex justify-content-center">
+                <div id="qrCode-@Model.Key!.Id"></div>
+            </div>
         </dd>
     </dl>
 </div>
@@ -30,3 +41,29 @@
     <a asp-page="../Index">Betreuerzugänge verwalten</a> |
     <a class="text-danger" asp-page="./Delete" asp-route-id="@Model.Key!.Id">Löschen</a>
 </div>
+
+@section Scripts {
+
+    <script type="text/javascript" src="~/lib/qrcodejs/qrcode.min.js"></script>
+    <script type="text/javascript">
+        function toggleQrCode(url, qr) {
+            qrCodeContainer = document.getElementById(qr);
+
+            if (qrCodeContainer.innerHTML.trim().length > 0) {
+                qrCodeContainer.innerHTML = "";
+                qrCodeContainer.classList.remove("mt-2");
+            }
+            else {
+                new QRCode(qrCodeContainer,
+                    {
+                        text: url,
+                        width: 150,
+                        height: 150
+                    });
+
+                qrCodeContainer.classList.add("mt-2");
+            }
+        }
+    </script>
+
+}

--- a/BwMelder/Pages/TeamCoaches/Keys/Details.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Keys/Details.cshtml
@@ -1,0 +1,32 @@
+﻿@page "{id:int}"
+@model BwMelder.Pages.TeamCoaches.Keys.DeleteModel
+
+@{
+    ViewData["Title"] = "Betreuerzugang";
+}
+
+<h1>@ViewData["Title"]</h1>
+<hr />
+
+<div>
+    <dl class="row">
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Key!.Comment)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Key!.Comment)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Key!.Secret)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Key!.Secret)
+        </dd>
+    </dl>
+</div>
+
+<div>
+    <a asp-page="../Index">Zurück zur Betreuerübersicht</a> |
+    <a asp-page="../Index">Betreuerzugänge verwalten</a> |
+    <a class="text-danger" asp-page="./Delete" asp-route-id="@Model.Key!.Id">Löschen</a>
+</div>

--- a/BwMelder/Pages/TeamCoaches/Keys/Details.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Keys/Details.cshtml.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using BwMelder.Data;
+using BwMelder.Model;
+
+namespace BwMelder.Pages.TeamCoaches.Keys
+{
+    public class DetailsModel : PageModel
+    {
+        private readonly BwMelderDbContext db;
+
+        public DetailsModel(BwMelderDbContext db)
+        {
+            this.db = db;
+        }
+
+        public TeamCoachKey? Key { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int id)
+        {
+            Key = await db.TeamCoachKeys
+                .AsNoTracking()
+                .SingleOrDefaultAsync(key => key.Id == id);
+
+            if (Key == null)
+            {
+                return NotFound();
+            }
+
+            return Page();
+        }
+    }
+}

--- a/BwMelder/Pages/TeamCoaches/Keys/Details.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Keys/Details.cshtml.cs
@@ -7,19 +7,24 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using BwMelder.Data;
 using BwMelder.Model;
+using Microsoft.AspNetCore.Http;
+using BwMelder.Extensions;
 
 namespace BwMelder.Pages.TeamCoaches.Keys
 {
     public class DetailsModel : PageModel
     {
         private readonly BwMelderDbContext db;
+        private readonly IHttpContextAccessor httpContextAccessor;
 
-        public DetailsModel(BwMelderDbContext db)
+        public DetailsModel(BwMelderDbContext db, IHttpContextAccessor httpContextAccessor)
         {
             this.db = db;
+            this.httpContextAccessor = httpContextAccessor;
         }
 
         public TeamCoachKey? Key { get; set; }
+        public string BaseUrl { get; set; } = string.Empty;
 
         public async Task<IActionResult> OnGetAsync(int id)
         {
@@ -32,7 +37,12 @@ namespace BwMelder.Pages.TeamCoaches.Keys
                 return NotFound();
             }
 
+            // Base URL is needed for generating the secret URLs team coaches are supposed to use.
+            BaseUrl = httpContextAccessor.HttpContext?.Request.BaseUrl() ?? string.Empty;
+
             return Page();
         }
+
+        public string GetSecretUrl(TeamCoachKey key) => $"{BaseUrl}TeamCoaches/Key/{key.Secret}";
     }
 }

--- a/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml
@@ -26,18 +26,56 @@
         </tr>
     </thead>
     <tbody>
-@foreach (var item in Model.TeamCoachKeys) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.Comment)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Secret)
-            </td>
-            <td>
-                <a class="text-danger" asp-page="./Delete" asp-route-id="@item.Id">Löschen</a>
-            </td>
-        </tr>
-}
+        @foreach (var item in Model.TeamCoachKeys)
+        {
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Comment)
+                </td>
+                <td>
+                    <div class="input-group">
+                        <input class="form-control" value="@Model.GetSecretUrl(item)" readonly />
+                        <div class="input-group-append">
+                            <button class="btn btn-outline-secondary" data-toggle="button"
+                                    onclick="toggleQrCode('@Model.GetSecretUrl(item)', 'qrCode-@item.Id')">
+                                QR-Code
+                            </button>
+                        </div>
+                    </div>
+                    <div class="d-flex justify-content-center">
+                        <div id="qrCode-@item.Id"></div>
+                    </div>
+                </td>
+                <td>
+                    <a class="text-danger" asp-page="./Delete" asp-route-id="@item.Id">Löschen</a>
+                </td>
+            </tr>
+        }
     </tbody>
 </table>
+
+@section Scripts {
+
+    <script type="text/javascript" src="~/lib/qrcodejs/qrcode.min.js"></script>
+    <script type="text/javascript">
+        function toggleQrCode(url, qr) {
+            qrCodeContainer = document.getElementById(qr);
+
+            if (qrCodeContainer.innerHTML.trim().length > 0) {
+                qrCodeContainer.innerHTML = "";
+                qrCodeContainer.classList.remove("mt-2");
+            }
+            else {
+                new QRCode(qrCodeContainer,
+                    {
+                        text: url,
+                        width: 150,
+                        height: 150
+                    });
+
+                qrCodeContainer.classList.add("mt-2");
+            }
+        }
+    </script>
+
+}

--- a/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml
@@ -55,27 +55,7 @@
 </table>
 
 @section Scripts {
-
-    <script type="text/javascript" src="~/lib/qrcodejs/qrcode.min.js"></script>
-    <script type="text/javascript">
-        function toggleQrCode(url, qr) {
-            qrCodeContainer = document.getElementById(qr);
-
-            if (qrCodeContainer.innerHTML.trim().length > 0) {
-                qrCodeContainer.innerHTML = "";
-                qrCodeContainer.classList.remove("mt-2");
-            }
-            else {
-                new QRCode(qrCodeContainer,
-                    {
-                        text: url,
-                        width: 150,
-                        height: 150
-                    });
-
-                qrCodeContainer.classList.add("mt-2");
-            }
-        }
-    </script>
-
+    @{
+        await Html.RenderPartialAsync("_QrCodeScriptsPartial");
+    }
 }

--- a/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml
+++ b/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml
@@ -1,0 +1,43 @@
+﻿@page
+@model BwMelder.Pages.TeamCoaches.Keys.IndexModel
+@{
+    ViewData["Title"] = "Betreuerzugänge";
+}
+
+<h1>@ViewData["Title"]</h1>
+<p>
+    Betreuer können ihre Daten über einen Betreuerzugang selbst eintragen und ändern.
+    Dafür ist keine Anmeldung notwendig, sondern ein spezieller, persönlicher Link.
+    Die hier gezeigten Zugänge wurden freigeschaltet, aber noch nicht verwendet.
+</p>
+<p>
+    <a class="btn btn-primary" asp-page="Create">Betreuerzugang anlegen</a>
+</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.TeamCoachKeys[0].Comment)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.TeamCoachKeys[0].Secret)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model.TeamCoachKeys) {
+        <tr>
+            <td>
+                @Html.DisplayFor(modelItem => item.Comment)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Secret)
+            </td>
+            <td>
+                <a class="text-danger" asp-page="./Delete" asp-route-id="@item.Id">Löschen</a>
+            </td>
+        </tr>
+}
+    </tbody>
+</table>

--- a/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using BwMelder.Data;
+using BwMelder.Model;
+
+namespace BwMelder.Pages.TeamCoaches.Keys
+{
+    public class IndexModel : PageModel
+    {
+        private readonly BwMelderDbContext db;
+
+        public IndexModel(BwMelderDbContext db)
+        {
+            this.db = db;
+        }
+
+        public IList<TeamCoachKey> TeamCoachKeys { get; set; } = new List<TeamCoachKey>();
+
+        public async Task OnGetAsync()
+        {
+            TeamCoachKeys = await db.TeamCoachKeys
+                .AsNoTracking()
+                .Where(key => key.TeamCoach == null)
+                .ToListAsync();
+        }
+    }
+}

--- a/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml.cs
@@ -37,6 +37,6 @@ namespace BwMelder.Pages.TeamCoaches.Keys
             BaseUrl = httpContextAccessor.HttpContext?.Request.BaseUrl() ?? string.Empty;
         }
 
-        public string GetSecretUrl(TeamCoachKey key) => $"{BaseUrl}TeamCoaches/Keys/{key.Secret}";
+        public string GetSecretUrl(TeamCoachKey key) => $"{BaseUrl}TeamCoaches/Key/{key.Secret}";
     }
 }

--- a/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml.cs
+++ b/BwMelder/Pages/TeamCoaches/Keys/Index.cshtml.cs
@@ -7,19 +7,25 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using BwMelder.Data;
 using BwMelder.Model;
+using Microsoft.AspNetCore.Http;
+using BwMelder.Extensions;
 
 namespace BwMelder.Pages.TeamCoaches.Keys
 {
     public class IndexModel : PageModel
     {
         private readonly BwMelderDbContext db;
+        private readonly IHttpContextAccessor httpContextAccessor;
 
-        public IndexModel(BwMelderDbContext db)
+        public IndexModel(BwMelderDbContext db, IHttpContextAccessor httpContextAccessor)
         {
             this.db = db;
+            this.httpContextAccessor = httpContextAccessor;
         }
 
         public IList<TeamCoachKey> TeamCoachKeys { get; set; } = new List<TeamCoachKey>();
+
+        public string BaseUrl { get; set; } = string.Empty;
 
         public async Task OnGetAsync()
         {
@@ -27,6 +33,10 @@ namespace BwMelder.Pages.TeamCoaches.Keys
                 .AsNoTracking()
                 .Where(key => key.TeamCoach == null)
                 .ToListAsync();
+
+            BaseUrl = httpContextAccessor.HttpContext?.Request.BaseUrl() ?? string.Empty;
         }
+
+        public string GetSecretUrl(TeamCoachKey key) => $"{BaseUrl}TeamCoaches/Keys/{key.Secret}";
     }
 }

--- a/BwMelder/Startup.cs
+++ b/BwMelder/Startup.cs
@@ -44,11 +44,11 @@ namespace BwMelder
                 options.Conventions.AllowAnonymousToFolder("/Crews/HomeCoaches");
 
                 // Allow anonymous access for team coaches so they can add themselves.
-                // Note that Index is not included.
+                // Note that Index and Delete are not included.
                 options.Conventions.AllowAnonymousToPage("/TeamCoaches/Create");
                 options.Conventions.AllowAnonymousToPage("/TeamCoaches/Details");
                 options.Conventions.AllowAnonymousToPage("/TeamCoaches/Edit");
-                options.Conventions.AllowAnonymousToPage("/TeamCoaches/Delete");
+                options.Conventions.AllowAnonymousToPage("/TeamCoaches/Key");
 
                 // Note that the homepage and login/logout are allowed for anonymous access by attributes.
             });


### PR DESCRIPTION
Team coaches can now register using a tokenized link just like crews. Admins can generate unique access links, team coaches can use them to register and edit their data later.