### PR TITLE
Fix access key login flow.

### DIFF
--- a/BwMelder.Web/Authentication/AuthenticationHandler.cs
+++ b/BwMelder.Web/Authentication/AuthenticationHandler.cs
@@ -8,8 +8,8 @@ namespace BwMelder.Web.Authentication;
 /// <summary>
 /// Handles authentication tasks for the application.
 /// </summary>
-public class AuthenticationHandler(IHttpContextAccessor httpContextAccessor, IUserAuthenticationService userAuthenticationService,
-    IAccessKeyService accessKeyService)
+public class AuthenticationHandler(IHttpContextAccessor httpContextAccessor,
+    IUserAuthenticationService userAuthenticationService, IAccessKeyService accessKeyService)
 {
     private HttpContext Context =>
         httpContextAccessor.HttpContext
@@ -21,7 +21,7 @@ public class AuthenticationHandler(IHttpContextAccessor httpContextAccessor, IUs
     public async Task LogoutAsync() => await Context.SignOutAsync();
 
     /// <summary>
-    /// Tries to login a user identified by the given secret.
+    /// Tries to log in a user identified by the given secret.
     /// </summary>
     /// <param name="secret">Secret provided by the user.</param>
     /// <returns>True if login completed successfully, false if it failed.</returns>
@@ -29,26 +29,24 @@ public class AuthenticationHandler(IHttpContextAccessor httpContextAccessor, IUs
     {
         var authResponse = await accessKeyService.AuthenticateAsync(secret);
 
-        if (authResponse.IsSuccess)
+        if (!authResponse.IsSuccess) { return false; }
+        
+        var claims = new List<Claim>
         {
-            var claims = new List<Claim>
-            {
-                // TODO: Should probably do null checks here, but too cumbersome.
-                new("ClubId", authResponse.ClubId!.Value.ToString()),
-                new("ClubName", authResponse.ClubName!),
-                new("OnboardingRequired", authResponse.OnboardingRequired.ToString().ToLower(), ClaimValueTypes.Boolean),
-                new(ClaimTypes.Role, authResponse.Role!)
-            };
-            var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
-            await LoginAsync(identity);
-            return true;
-        }
-
-        return false;
+            // TODO: Should probably do null checks here, but too cumbersome.
+            new("ClubId", authResponse.ClubId!.Value.ToString()),
+            new("ClubName", authResponse.ClubName!),
+            new("OnboardingRequired", authResponse.OnboardingRequired.ToString().ToLower(), ClaimValueTypes.Boolean),
+            new(ClaimTypes.Role, authResponse.Role!)
+        };
+        var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        await LoginAsync(identity);
+        
+        return true;
     }
 
     /// <summary>
-    /// Tries to login a user identified by the given credentials.
+    /// Tries to log in a user identified by the given credentials.
     /// </summary>
     /// <param name="credentials">Credentials provided by the user.</param>
     /// <returns>True if login completed successfully, false if it failed.</returns>
@@ -56,20 +54,18 @@ public class AuthenticationHandler(IHttpContextAccessor httpContextAccessor, IUs
     {
         var authResponse = await userAuthenticationService.AuthenticateAsync(credentials);
 
-        if (authResponse.IsSuccess)
+        if (!authResponse.IsSuccess) { return false; }
+        
+        var claims = new List<Claim>
         {
-            var claims = new List<Claim>
-            {
-                // TODO: Should probably do null checks here, but too cumbersome.
-                new(ClaimTypes.Name, "Administrator"),
-                new(ClaimTypes.Role, authResponse.Role!)
-            };
-            var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
-            await LoginAsync(identity);
-            return true;
-        }
-
-        return false;
+            // TODO: Should probably do null checks here, but too cumbersome.
+            new(ClaimTypes.Name, "Administrator"),
+            new(ClaimTypes.Role, authResponse.Role!)
+        };
+        var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        await LoginAsync(identity);
+        
+        return true;
     }
 
     /// <summary>

--- a/BwMelder.Web/Authentication/AuthenticationStateExtensions.cs
+++ b/BwMelder.Web/Authentication/AuthenticationStateExtensions.cs
@@ -12,21 +12,21 @@ public static class AuthenticationStateExtensions
     /// <returns>User information; null if no authenticated user.</returns>
     public static async Task<UserInfo?> GetUserInfoAsync(this Task<AuthenticationState>? task)
     {
-        if (task is not null)
-        {
-            var authenticationState = await task;
-            var user = authenticationState.User;
+        if (task is null) { return null; }
 
-            if (user?.Identity is not null && user.Identity.IsAuthenticated)
+        var authenticationState = await task;
+        var user = authenticationState.User;
+
+        if (user.Identity is not null && user.Identity.IsAuthenticated)
+        {
+            return new UserInfo
             {
-                return new UserInfo
-                {
-                    Role = user.FindFirstValue(ClaimTypes.Role) ?? string.Empty,
-                    ClubId = Guid.TryParse(user.FindFirstValue("ClubId"), out var guid) ? guid : null,
-                    ClubName = user.FindFirstValue("ClubName") ?? string.Empty
-                };
-            }
+                Role = user.FindFirstValue(ClaimTypes.Role) ?? string.Empty,
+                ClubId = Guid.TryParse(user.FindFirstValue("ClubId"), out var guid) ? guid : null,
+                ClubName = user.FindFirstValue("ClubName") ?? string.Empty
+            };
         }
+
         return null;
     }
 
@@ -41,11 +41,9 @@ public static class AuthenticationStateExtensions
     /// </remarks>
     public static async Task<UserInfo?> GetUserInfoAsync(this AuthenticationStateProvider? provider)
     {
-        if (provider is not null)
-        {
-            var task = provider.GetAuthenticationStateAsync();
-            return await task.GetUserInfoAsync();
-        }
-        return null;
+        if (provider is null) { return null; }
+
+        var task = provider.GetAuthenticationStateAsync();
+        return await task.GetUserInfoAsync();
     }
 }

--- a/BwMelder.Web/Features/Login/AccessKeyLoginEndpoint.cs
+++ b/BwMelder.Web/Features/Login/AccessKeyLoginEndpoint.cs
@@ -26,6 +26,9 @@ internal class AccessKeyLoginEndpoint : IDiscoverableEndpoint
         return Results.NotFound();
     }
 
+    /// <summary>
+    /// Redirects a club coach to their next step.
+    /// </summary>
     [Authorize(Roles = "ClubCoach")]
     private static async Task<IResult> RouteClubCoach(IAuthorizationService authorization, HttpContext context)
     {

--- a/BwMelder.Web/Features/Login/AccessKeyLoginEndpoint.cs
+++ b/BwMelder.Web/Features/Login/AccessKeyLoginEndpoint.cs
@@ -4,27 +4,33 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace BwMelder.Web.Features.Login;
 
-class AccessKeyLoginEndpoint : IDiscoverableEndpoint
+internal class AccessKeyLoginEndpoint : IDiscoverableEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
         app.MapGet("/go/{secret}", LoginWithSecret);
+        app.MapGet("/go/continue", RouteClubCoach);
     }
 
     /// <summary>
     /// Logs in the user with the given secret.
     /// </summary>
-    static async Task<IResult> LoginWithSecret(string secret, AuthenticationHandler authHandler, HttpContext context,
-        IAuthorizationService authorization)
+    private static async Task<IResult> LoginWithSecret(string secret, AuthenticationHandler authHandler)
     {
         if (await authHandler.LoginAsync(secret))
         {
-            if ((await authorization.AuthorizeAsync(context.User, "ClubIsOnboarded")).Succeeded)
-            {
-                return Results.Redirect("/");
-            }
-            return Results.Redirect("/onboarding/welcome");
+            // The signed-in user context is only available in subsequent HTTP requests.
+            // Redirect will trigger a new request so the next steps can be determined.
+            return Results.Redirect("/go/continue");
         }
         return Results.NotFound();
+    }
+
+    [Authorize(Roles = "ClubCoach")]
+    private static async Task<IResult> RouteClubCoach(IAuthorizationService authorization, HttpContext context)
+    {
+        // Determine if onboarding must be completed.
+        var authorizationResult = await authorization.AuthorizeAsync(context.User, "ClubIsOnboarded");
+        return Results.Redirect(authorizationResult.Succeeded ? "/" : "/onboarding/welcome");
     }
 }


### PR DESCRIPTION
Add a second endpoint to route club coaches based on their user information. Previous implementation did not work reliably as the user context was not set when authorization was checked.